### PR TITLE
fix plugin so that instance works with multiple video players on a si…

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,13 @@ Tech plugin for VideoJS to support Scene7 players
 
 - [Installation](#installation)
 - [Usage](#usage)
-  - [`<script>` Tag](#script-tag)
+  - [`<script>` Tag with a `<video>` tag](#script-tag-with-a-video-tag)
   - [Browserify/CommonJS](#browserifycommonjs)
   - [RequireJS/AMD](#requirejsamd)
+- [Options](#options)
+  - [`serverurl`](#serverurl)
+  - [`videoserverurl`](#videoserverurl)
+  - [`contenturl`](#contenturl)
 - [License](#license)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "npm-run-all": "^4.0.2",
     "qunitjs": "^2.3.2",
     "rimraf": "^2.6.1",
-    "rollup": "^0.41.6",
+    "rollup": "^0.48.0",
     "rollup-plugin-babel": "^2.7.1",
     "rollup-plugin-commonjs": "^8.0.2",
     "rollup-plugin-json": "^2.1.1",

--- a/scripts/modules.rollup.config.js
+++ b/scripts/modules.rollup.config.js
@@ -10,7 +10,7 @@ import json from 'rollup-plugin-json';
 
 export default {
   moduleName: 'videojsScene7',
-  entry: 'src/plugin.js',
+  input: 'src/plugin.js',
   external: [
     'global',
     'global/document',

--- a/scripts/test.rollup.config.js
+++ b/scripts/test.rollup.config.js
@@ -11,7 +11,7 @@ import resolve from 'rollup-plugin-node-resolve';
 
 export default {
   moduleName: 'videojsScene7Tests',
-  entry: 'test/**/*.test.js',
+  input: ['test/**/*.test.js'],
   dest: 'test/dist/bundle.js',
   format: 'iife',
   external: [

--- a/scripts/umd.rollup.config.js
+++ b/scripts/umd.rollup.config.js
@@ -11,7 +11,7 @@ import resolve from 'rollup-plugin-node-resolve';
 
 export default {
   moduleName: 'videojsScene7',
-  entry: 'src/plugin.js',
+  input: 'src/plugin.js',
   dest: 'dist/videojs-scene7.js',
   format: 'umd',
   external: ['video.js'],

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -192,7 +192,7 @@ class Scene7 extends Tech {
 
     that.el_.id = that.el_.id || that.getUniqueId();
 
-    const container = new sdk.common.Container(that.el_.id, params, that.el_.id + "-s7container");
+    const container = new sdk.common.Container(that.el_.id, params, that.el_.id + '-s7container');
 
     // Setup events to resize the player when the container changes size/fullscreen
     container.addEventListener(sdk.event.ResizeEvent.COMPONENT_RESIZE, function(event) {
@@ -726,7 +726,9 @@ class Scene7 extends Tech {
    */
   getUniqueId() {
     return 'x-' + 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-      var r = Math.random() * 16 | 0, v = c == 'x' ? r : (r&0x3 | 0x8);
+      const r = Math.random() * 16 | 0;
+      const v = c === 'x' ? r : (r & 0x3 | 0x8);
+
       return v.toString(16);
     });
   }

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -143,8 +143,8 @@ class Scene7 extends Tech {
    */
   _initViewer() {
     this.setParameters();
-    this._setupS7MediaSet();
     this._setupS7Container();
+    this._setupS7MediaSet();
     this._setupS7Player();
     this._mapEvents();
     this.injectS7Player();
@@ -160,6 +160,7 @@ class Scene7 extends Tech {
   _setupS7MediaSet(src) {
     const that = this;
     const sdk = that.s7.sdk;
+    const container = that.s7.container;
     const params = that.s7.params;
     let mediaSet = {};
 
@@ -169,7 +170,7 @@ class Scene7 extends Tech {
     }
 
     // Get new MediaSet object
-    mediaSet = new sdk.set.MediaSet(null, params, 'mediaSet');
+    mediaSet = new sdk.set.MediaSet(container, params, container.parentId + '-s7mediaSet');
 
     // Add MediaSet event listeners
     mediaSet.addEventListener(sdk.event.AssetEvent.NOTF_SET_PARSED, function(event) {
@@ -188,7 +189,10 @@ class Scene7 extends Tech {
     const that = this;
     const sdk = that.s7.sdk;
     const params = that.s7.params;
-    const container = new sdk.common.Container(null, params, 'cont');
+
+    that.el_.id = that.el_.id || that.getUniqueId();
+
+    const container = new sdk.common.Container(that.el_.id, params, that.el_.id + "-s7container");
 
     // Setup events to resize the player when the container changes size/fullscreen
     container.addEventListener(sdk.event.ResizeEvent.COMPONENT_RESIZE, function(event) {
@@ -223,7 +227,7 @@ class Scene7 extends Tech {
     const sdk = that.s7.sdk;
     const container = that.s7.container;
     const params = that.s7.params;
-    const player = new sdk.video.VideoPlayer(container, params, 's7viewer');
+    const player = new sdk.video.VideoPlayer(container, params, container.parentId + '-s7viewer');
 
     that.s7.player = player;
   }
@@ -714,6 +718,17 @@ class Scene7 extends Tech {
 
     that.resizeContainer(vjsEl.offsetWidth, vjsEl.offsetHeight);
     that.resizeVideo(vjsEl.offsetWidth, vjsEl.offsetHeight);
+  }
+
+  /**
+   * Genterate a unique id
+   * http://stackoverflow.com/questions/105034/create-guid-uuid-in-javascript
+   */
+  getUniqueId() {
+    return 'x-' + 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+      var r = Math.random() * 16 | 0, v = c == 'x' ? r : (r&0x3 | 0x8);
+      return v.toString(16);
+    });
   }
 }
 


### PR DESCRIPTION
**What does this PR do?**
This PR updates the plugin so that it works when multiple players on a page at the same time. A fix for defect https://github.com/amclin/videojs-scene7/issues/10.

Previously, the id given to the S7 container, player and media object were the same for each instance. This chance will give the container element a unique ID if it doesn't already have one. Then the container's inner content, player, and media object will all be given unique IDs extending on the container's ID.

This can be tested here - Multiple S7 AVS - https://www.eaglecreek.com/test/s7-adaptive-video-player-multi.html