### PR TITLE
test: supports unit tests in Safari on Mojave

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6691,10 +6691,10 @@
       "integrity": "sha1-iCUq/SEnvAOwzDGXjtaIKxOfRwo=",
       "dev": true
     },
-    "karma-safari-launcher": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/karma-safari-launcher/-/karma-safari-launcher-1.0.0.tgz",
-      "integrity": "sha1-lpgqLMR9BmquccVTursoMZEVos4=",
+    "karma-safarinative-launcher": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/karma-safarinative-launcher/-/karma-safarinative-launcher-1.1.0.tgz",
+      "integrity": "sha512-vdMjdQDHkSUbOZc8Zq2K5bBC0yJGFEgfrKRJTqt0Um0SC1Rt8drS2wcN6UA3h4LgsL3f1pMcmRSvKucbJE8Qdg==",
       "dev": true
     },
     "kind-of": {

--- a/package.json
+++ b/package.json
@@ -75,12 +75,12 @@
     "video.js": "^5.19.2"
   },
   "devDependencies": {
+    "@commitlint/cli": "^7.5.2",
+    "@commitlint/config-angular": "^7.5.0",
     "@semantic-release/exec": "^3.3.2",
     "@semantic-release/git": "^7.0.8",
     "@semantic-release/github": "^5.2.10",
     "@semantic-release/npm": "^5.1.4",
-    "@commitlint/cli": "^7.5.2",
-    "@commitlint/config-angular": "^7.5.0",
     "babel-plugin-external-helpers": "^6.22.0",
     "babel-plugin-transform-object-assign": "^6.8.0",
     "babel-preset-es2015": "^6.14.0",
@@ -98,7 +98,7 @@
     "karma-firefox-launcher": "^1.0.1",
     "karma-ie-launcher": "^1.0.0",
     "karma-qunit": "^1.2.1",
-    "karma-safari-launcher": "^1.0.0",
+    "karma-safarinative-launcher": "^1.1.0",
     "mkdirp": "^0.5.1",
     "node-static": "^0.7.9",
     "npm-run-all": "^4.0.2",

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -28,6 +28,11 @@ module.exports = function(config) {
       travisChrome: {
         base: 'Chrome',
         flags: ['--no-sandbox']
+      },
+      // TODO: Remove karma-safari-nativelauncher and replace with karma-safari-launcer if issue is resolved
+      // Safari on Mojave doesn't launch the same way: https://github.com/karma-runner/karma-safari-launcher/issues/29
+      Safari: {
+        base: 'SafariNative'
       }
     },
     detectBrowsers: detectBrowsers,


### PR DESCRIPTION
Uses a different package for launching Safari in the Karma unit tests to work around the bug reported in https://github.com/karma-runner/karma-safari-launcher/issues/29