### PR TITLE
ci: set travis to use NodeJS latest current and latest LTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: trusty
 language: node_js
 node_js:
   - 'node'
-  - 'lts/boron'
+  - 'lts/*'
 before_script:
 
   # Check if the current version is equal to the major version for the env.


### PR DESCRIPTION
lts/boron is Node 6.5 and is woefully out-of-date. Updates to leverage latest long-term-support version when running tests on Travis