### PR TITLE
refactor: update rollup configs to newer syntax

### DIFF
--- a/scripts/modules.rollup.config.js
+++ b/scripts/modules.rollup.config.js
@@ -9,7 +9,7 @@ import babel from 'rollup-plugin-babel';
 import json from 'rollup-plugin-json';
 
 export default {
-  moduleName: 'videojsScene7',
+  name: 'videojsScene7',
   input: 'src/plugin.js',
   external: [
     'global',
@@ -38,8 +38,13 @@ export default {
       ]
     })
   ],
-  targets: [
-    {dest: 'dist/videojs-scene7.cjs.js', format: 'cjs'},
-    {dest: 'dist/videojs-scene7.es.js', format: 'es'}
+  output: [
+    {
+      file: 'dist/videojs-scene7.cjs.js',
+      format: 'cjs'
+    }, {
+      file: 'dist/videojs-scene7.es.js',
+      format: 'es'
+    }
   ]
 };

--- a/scripts/test.rollup.config.js
+++ b/scripts/test.rollup.config.js
@@ -10,10 +10,12 @@ import multiEntry from 'rollup-plugin-multi-entry';
 import resolve from 'rollup-plugin-node-resolve';
 
 export default {
-  moduleName: 'videojsScene7Tests',
+  name: 'videojsScene7Tests',
   input: ['test/**/*.test.js'],
-  dest: 'test/dist/bundle.js',
-  format: 'iife',
+  output: {
+    file: 'test/dist/bundle.js',
+    format: 'iife'
+  },
   external: [
     'qunit',
     'qunitjs',

--- a/scripts/umd.rollup.config.js
+++ b/scripts/umd.rollup.config.js
@@ -10,10 +10,12 @@ import json from 'rollup-plugin-json';
 import resolve from 'rollup-plugin-node-resolve';
 
 export default {
-  moduleName: 'videojsScene7',
+  name: 'videojsScene7',
   input: 'src/plugin.js',
-  dest: 'dist/videojs-scene7.js',
-  format: 'umd',
+  output: {
+    file: 'dist/videojs-scene7.js',
+    format: 'umd'
+  },
   external: ['video.js'],
   globals: {
     'video.js': 'videojs'


### PR DESCRIPTION
Resolves warnings output by rollup regarding config changes. Unblocks updates to later versions of rollup.

```
test/**/*.test.js → test/dist/bundle.js...
(!) Some options have been renamed
https://gist.github.com/Rich-Harris/d472c50732dab03efeb37472b08a3f32
options.moduleName is now options.name
options.targets is now options.output
output.dest is now output.file
```