### PR TITLE
Fix/js errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,21 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@babel/runtime": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.4.tgz",
-      "integrity": "sha512-IvfvnMdSaLBateu0jfsYIpZTxAc2cKEXEMiezGGN75QcBcecDUKd3PgLAncT0oOgxKy8dd8hrJKj9MfzgfZd6g==",
-      "requires": {
-        "regenerator-runtime": "^0.12.0"
-      },
-      "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.12.1",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
-        }
-      }
-    },
     "@commitlint/cli": {
       "version": "7.5.2",
       "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-7.5.2.tgz",
@@ -737,20 +722,6 @@
       "integrity": "sha512-wp6IOGu1lxsfnrD+5mX6qwSwWuqsdkKKxTN4aQc4wByHAKZJf9/D4KXPQ1POUjEbnCP5LMggB0OEFNY9OTsMqg==",
       "dev": true
     },
-    "@videojs/http-streaming": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@videojs/http-streaming/-/http-streaming-1.5.1.tgz",
-      "integrity": "sha512-Pc3aVr4SRINFLhUWjTofVjQ9iMjs9myXnyfJ0AdW0c4bLwJ0Fw7HUsbns+qseuBzVJe01i7J2R/DE1Y4hFgblA==",
-      "requires": {
-        "aes-decrypter": "3.0.0",
-        "global": "^4.3.0",
-        "m3u8-parser": "4.2.0",
-        "mpd-parser": "0.7.0",
-        "mux.js": "5.0.1",
-        "url-toolkit": "^2.1.3",
-        "video.js": "^6.8.0 || ^7.0.0"
-      }
-    },
     "JSONStream": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
@@ -805,16 +776,6 @@
       "resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
       "integrity": "sha1-anmQQ3ynNtXhKI25K9MmbV9csqo=",
       "dev": true
-    },
-    "aes-decrypter": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/aes-decrypter/-/aes-decrypter-3.0.0.tgz",
-      "integrity": "sha1-eEihwUW5/b9Xrj4rWxvHzwZEqPs=",
-      "requires": {
-        "commander": "^2.9.0",
-        "global": "^4.3.2",
-        "pkcs7": "^1.0.2"
-      }
     },
     "after": {
       "version": "0.8.2",
@@ -1637,7 +1598,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "dev": true,
       "requires": {
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.11.0"
@@ -2353,7 +2313,8 @@
     "commander": {
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
-      "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
+      "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
+      "dev": true
     },
     "comment-parser": {
       "version": "0.5.4",
@@ -2715,8 +2676,7 @@
     "core-js": {
       "version": "2.6.5",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
-      "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==",
-      "dev": true
+      "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -3288,6 +3248,11 @@
         "es6-symbol": "~3.1.1",
         "next-tick": "^1.0.0"
       }
+    },
+    "es5-shim": {
+      "version": "4.5.12",
+      "resolved": "https://registry.npmjs.org/es5-shim/-/es5-shim-4.5.12.tgz",
+      "integrity": "sha512-MjoCAHE6P2Dirme70Cxd9i2Ng8rhXiaVSsxDWdSwimfLERJL/ypR2ed2rTYkeeYrMk8gq281dzKLiGcdrmc8qg=="
     },
     "es6-iterator": {
       "version": "2.0.3",
@@ -6453,11 +6418,6 @@
         "yallist": "^2.1.2"
       }
     },
-    "m3u8-parser": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/m3u8-parser/-/m3u8-parser-4.2.0.tgz",
-      "integrity": "sha512-LVHw0U6IPJjwk9i9f7Xe26NqaUHTNlIt4SSWoEfYFROeVKHN6MIjOhbRheI3dg8Jbq5WCuMFQ0QU3EgZpmzFPg=="
-    },
     "macos-release": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.1.0.tgz",
@@ -6825,15 +6785,6 @@
       "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
       "dev": true
     },
-    "mpd-parser": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/mpd-parser/-/mpd-parser-0.7.0.tgz",
-      "integrity": "sha512-nkzVIkecaDz3q7p4ToN3GR0FV2Odbh0w2sJ8ijsyw79JcBrJoUD3KHIiI8gL0hEDlex7mrVpTxXBsRHowUBmPw==",
-      "requires": {
-        "global": "^4.3.2",
-        "url-toolkit": "^2.1.1"
-      }
-    },
     "ms": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
@@ -6845,11 +6796,6 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
       "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
       "dev": true
-    },
-    "mux.js": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-5.0.1.tgz",
-      "integrity": "sha512-yfmJ9CaLGSyRnEwqwzvISSZe6EdcvXIsgapZfuNNFuUQUlYDwltnCgZqV6IG90daY4dYTemK/hxMoxI1bB6RjA=="
     },
     "nan": {
       "version": "2.13.1",
@@ -10627,11 +10573,6 @@
         "pinkie": "^2.0.0"
       }
     },
-    "pkcs7": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pkcs7/-/pkcs7-1.0.2.tgz",
-      "integrity": "sha1-ttulJ1KMKUK/wSLOLa/NteWQdOc="
-    },
     "pkg-conf": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.1.0.tgz",
@@ -11015,8 +10956,7 @@
     "regenerator-runtime": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-      "dev": true
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
     },
     "regenerator-transform": {
       "version": "0.10.1",
@@ -12885,11 +12825,6 @@
       "integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE=",
       "dev": true
     },
-    "url-toolkit": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/url-toolkit/-/url-toolkit-2.1.6.tgz",
-      "integrity": "sha512-UaZ2+50am4HwrV2crR/JAf63Q4VvPYphe63WGeoJxeu8gmOm0qxPt+KsukfakPNrX9aymGNEkkaoICwn+OuvBw=="
-    },
     "use": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
@@ -12982,24 +12917,44 @@
       }
     },
     "video.js": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/video.js/-/video.js-7.4.1.tgz",
-      "integrity": "sha512-UmTHiJWcil8YN65M1t/d63X6ofLtQwnvJoYEN4VKzkECYIHbgzvMRgOmrf5bNtVeDC6JsFKLZQXJ7s6Au2jgcQ==",
+      "version": "5.20.5",
+      "resolved": "https://registry.npmjs.org/video.js/-/video.js-5.20.5.tgz",
+      "integrity": "sha1-RFza4gS85Fl4LYajGyWjKv1tjv8=",
       "requires": {
-        "@babel/runtime": "^7.2.0",
-        "@videojs/http-streaming": "1.5.1",
-        "global": "4.3.2",
+        "babel-runtime": "^6.9.2",
+        "global": "4.3.0",
         "safe-json-parse": "4.0.0",
         "tsml": "1.0.1",
-        "videojs-font": "3.1.0",
-        "videojs-vtt.js": "0.14.1",
-        "xhr": "2.4.0"
+        "videojs-font": "2.0.0",
+        "videojs-ie8": "1.1.2",
+        "videojs-swf": "5.4.1",
+        "videojs-vtt.js": "0.12.6",
+        "xhr": "2.2.2"
+      },
+      "dependencies": {
+        "global": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/global/-/global-4.3.0.tgz",
+          "integrity": "sha1-737EvurVebRU9evV5/MD21T0Kis=",
+          "requires": {
+            "min-document": "^2.6.1",
+            "process": "~0.5.1"
+          }
+        }
       }
     },
     "videojs-font": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/videojs-font/-/videojs-font-3.1.0.tgz",
-      "integrity": "sha512-rxB68SVgbHD+kSwoNWNCHicKJuR2ga3bGfvGxmB+8fupsiLbnyCwTBVtrZUq4bZnD64mrKP1DxHiutxwrs59pQ=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/videojs-font/-/videojs-font-2.0.0.tgz",
+      "integrity": "sha1-r3Rh751LleAzS/+3iy8v8DZKkDQ="
+    },
+    "videojs-ie8": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/videojs-ie8/-/videojs-ie8-1.1.2.tgz",
+      "integrity": "sha1-oj09hgitcZK2nGB3/E64SJmNNdk=",
+      "requires": {
+        "es5-shim": "^4.5.1"
+      }
     },
     "videojs-standard": {
       "version": "6.0.6",
@@ -13025,10 +12980,15 @@
         }
       }
     },
+    "videojs-swf": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/videojs-swf/-/videojs-swf-5.4.1.tgz",
+      "integrity": "sha1-IHfvccdJ8seCPvSbq65N0qywj4c="
+    },
     "videojs-vtt.js": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/videojs-vtt.js/-/videojs-vtt.js-0.14.1.tgz",
-      "integrity": "sha512-YxOiywx6N9t3J5nqsE5WN2Sw4CSqVe3zV+AZm2T4syOc2buNJaD6ZoexSdeszx2sHLU/RRo2r4BJAXFDQ7Qo2Q==",
+      "version": "0.12.6",
+      "resolved": "https://registry.npmjs.org/videojs-vtt.js/-/videojs-vtt.js-0.12.6.tgz",
+      "integrity": "sha512-XFXeGBQiljnElMhwCcZst0RDbZn2n8LU7ZScXryd3a00OaZsHAjdZu/7/RdSr7Z1jHphd45FnOvOQkGK4YrWCQ==",
       "requires": {
         "global": "^4.3.1"
       }
@@ -13171,9 +13131,9 @@
       "dev": true
     },
     "xhr": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.4.0.tgz",
-      "integrity": "sha1-4W5mpF+GmGHu76tBbV7/ci3ECZM=",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.2.2.tgz",
+      "integrity": "sha1-LuclcYafhobUFVmp6ihsGJcUNf8=",
       "requires": {
         "global": "~4.3.0",
         "is-function": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   ],
   "dependencies": {
     "global": "^4.3.2",
-    "video.js": "^7.4.1"
+    "video.js": "^5.19.2"
   },
   "devDependencies": {
     "@commitlint/cli": "^7.5.2",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   ],
   "dependencies": {
     "global": "^4.3.2",
-    "video.js": "^5.19.2"
+    "video.js": "^5.20.5"
   },
   "devDependencies": {
     "@commitlint/cli": "^7.5.2",


### PR DESCRIPTION
This plugin doesn't work fully with VideoJS 7. Rollback the copy of Video JS used for local testing to the latest version of V5 so that local testing can continue.