### PR TITLE
ci(travis): change chrome configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,11 +28,7 @@ env:
   - VJS=7
 addons:
   firefox: latest
-  apt:
-    sources:
-    - google-chrome
-    packages:
-    - google-chrome-stable
+  chrome: stable
 jobs:
   include:
     # Define the release stage that runs semantic-release


### PR DESCRIPTION
Travis is failing, possibly due to a change in how Chrome should be included as
a dependency. This update follows the Travis docs.