### PR TITLE
ci: restore browser autodetection

### DIFF
--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -4,14 +4,7 @@ module.exports = function(config) {
     usePhantomJS: false
   };
 
-  // On GitHub Actions with Ubuntu 20, both Chromium and Chrome are provided, but
-  // only Chrome is launchable. See https://github.com/amclin/videojs-scene7/issues/596
-  // TODO: Remove this so Chromium is tested as well
-  if (process.env.GITHUB_ACTIONS) {
-    config.browsers = ['Firefox', 'Chrome']
-  }
-
-  // If no browsers are specified, we enable `karma-detect-browsers`
+  // If no browsers are explicitly specified, we enable `karma-detect-browsers`
   // this will detect all browsers that are available for testing
   if (!config.browsers.length) {
     detectBrowsers.enabled = true;


### PR DESCRIPTION
Reverts #597, removing the workaround for Chromium having
permissions errors when launched on GitHub Actions.

See https://github.com/actions/virtual-environments/issues/2967