### PR TITLE
feat(security): switch all HTTP to HTTPS

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-# http://editorconfig.org
+# https://editorconfig.org
 root = true
 
 [*]

--- a/README.md
+++ b/README.md
@@ -84,23 +84,23 @@ Provide Scene7 options to VideoJS through the normal VideoJS options object or d
 ```js
 options: {
   scene7: {
-    serverurl: "http://s7d1.scene7.com/is/image/", // Path to Scene7 server
-    videoserverurl: "http://s7d1.scene7.com/is/content/", // 
+    serverurl: "https://s7d1.scene7.com/is/image/", // Path to Scene7 server
+    videoserverurl: "https://s7d1.scene7.com/is/content/", // 
   }
 }
 ```
 
 ### `serverurl`
 
-URL to the image API for Scene7. Default when not set is `http://s7d1.scene7.com/is/image/`
+URL to the image API for Scene7. Default when not set is `https://s7d1.scene7.com/is/image/`
 
 ### `videoserverurl`
 
-URL to the content API for Scene7. Default when not set is `http://s7d1.scene7.com/is/content/`
+URL to the content API for Scene7. Default when not set is `https://s7d1.scene7.com/is/content/`
 
 ### `contenturl`
 
-URL to the content API for Scene7 where losed caption and chapter navigation assets are located. Default when not set is `http://s7d1.scene7.com/is/content/`
+URL to the content API for Scene7 where losed caption and chapter navigation assets are located. Default when not set is `https://s7d1.scene7.com/is/content/`
 
 
 ## License
@@ -108,7 +108,7 @@ URL to the content API for Scene7 where losed caption and chapter navigation ass
 MIT. Copyright (c) Anthony McLin &lt;npm@anthonymclin.com&gt;
 
 
-[videojs]: http://videojs.com/
+[videojs]: https://videojs.com/
 
 [codecov-icon]: https://codecov.io/gh/amclin/videojs-scene7/branch/master/graph/badge.svg?token=qT4GevGPZO
 

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     id="videojs-scene7-player"
     class="video-js vjs-default-skin"
     controls
-    data-setup='{ "scene7": { "serverurl": "http://s7d1.scene7.com/is/image/", "videoserverurl": "http://s7d1.scene7.com/is/content/", "contenturl": "http://s7d1.scene7.com/is/content/"} }'
+    data-setup='{ "scene7": { "serverurl": "https://s7d1.scene7.com/is/image/", "videoserverurl": "https://s7d1.scene7.com/is/content/", "contenturl": "https://s7d1.scene7.com/is/content/"} }'
     loop
   >
     <source src="Scene7SharedAssets/Adobe_QBP-AVS" type='videojs/scene7'>
@@ -21,7 +21,7 @@
     <li><a href="docs/api/">Read generated docs.</a></li>
   </ul>
 
-  <script src="http://s7d1.scene7.com/s7sdk/3.0/js/s7sdk/utils/Utils.js"></script>
+  <script src="https://s7d1.scene7.com/s7sdk/3.0/js/s7sdk/utils/Utils.js"></script>
   <script src="node_modules/video.js/dist/video.js"></script>
   <script src="dist/videojs-scene7.js"></script>
   <script>

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -6,10 +6,10 @@ const Tech = videojs.getComponent('Tech');
 
 // Default options for the plugin.
 const defaults = {
-  serverurl: 'http://s7d1.scene7.com/is/image/',
-  videoserverurl: 'http://s7d1.scene7.com/is/content/',
+  serverurl: 'https://s7d1.scene7.com/is/image/',
+  videoserverurl: 'https://s7d1.scene7.com/is/content/',
   // specify content url for closed caption and chapter navigation asset
-  contenturl: 'http://s7d1.scene7.com/is/content/',
+  contenturl: 'https://s7d1.scene7.com/is/content/',
   // configures the icon effect when video is in paused state
   // as follows: enable,# times to appear, fade duration, auto-hide duration
   iconeffect: '0,-1,0.3,0'
@@ -727,7 +727,7 @@ class Scene7 extends Tech {
 
   /**
    * Genterate a unique id
-   * http://stackoverflow.com/questions/105034/create-guid-uuid-in-javascript
+   * https://stackoverflow.com/questions/105034/create-guid-uuid-in-javascript
    *
    * @return {string} A unique ID in the format x-xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx
    */

--- a/test/index.html
+++ b/test/index.html
@@ -5,7 +5,7 @@
   <title>videojs-scene7 Unit Tests</title>
   <link rel="stylesheet" href="../node_modules/qunit/qunit/qunit.css">
   <link rel="stylesheet" href="../node_modules/video.js/dist/video-js.css">
-<!--   <script src="http://s7d1.scene7.com/s7sdk/3.0/js/s7sdk/utils/Utils.js"></script> -->
+<!--   <script src="https://s7d1.scene7.com/s7sdk/3.0/js/s7sdk/utils/Utils.js"></script> -->
 </head>
 <body>
   <div id="qunit"></div>

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -28,7 +28,7 @@ const testOptions = {
 function _addS7Script() {
   // const sdktag = document.createElement('script');
 
-  // sdktag.src = 'http://s7d1.scene7.com/s7sdk/3.0/js/s7sdk/utils/Utils.js';
+  // sdktag.src = 'https://s7d1.scene7.com/s7sdk/3.0/js/s7sdk/utils/Utils.js';
   // document.head.appendChild(sdktag);
 
   window.s7sdk = s7faker;
@@ -200,20 +200,20 @@ QUnit.module('videojs-scene7', {
 
       assert.strictEqual(
         this.Scene7.s7.params.serverurl,
-        'http://s7d1.scene7.com/is/image/',
-        'defaults serverurl to http://s7d1.scene7.com/is/image/'
+        'https://s7d1.scene7.com/is/image/',
+        'defaults serverurl to https://s7d1.scene7.com/is/image/'
       );
 
       assert.strictEqual(
         this.Scene7.s7.params.videoserverurl,
-        'http://s7d1.scene7.com/is/content/',
-        'defaults videoserverurl to http://s7d1.scene7.com/is/content/'
+        'https://s7d1.scene7.com/is/content/',
+        'defaults videoserverurl to https://s7d1.scene7.com/is/content/'
       );
 
       assert.strictEqual(
         this.Scene7.s7.params.contenturl,
-        'http://s7d1.scene7.com/is/content/',
-        'defaults contenturl to http://s7d1.scene7.com/is/content/'
+        'https://s7d1.scene7.com/is/content/',
+        'defaults contenturl to https://s7d1.scene7.com/is/content/'
       );
     });
 


### PR DESCRIPTION
BREAKING CHANGE: defaults are now https instead of http

Connections to Adobe-provided scripts are now done using HTTPS instead of HTTP. Should not be an issue except in old insecure environments. Fixes #1034